### PR TITLE
Support for Laravel 5.4

### DIFF
--- a/src/Provider/FfmpegServiceProvider.php
+++ b/src/Provider/FfmpegServiceProvider.php
@@ -33,7 +33,7 @@ class FfmpegServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app['ffmpeg'] = $this->app->share(function($app)
+        $this->app->singleton('ffmpeg', function($app)
         {
             return new FFMPEG;
         });


### PR DESCRIPTION
Fixes Error                                                                        
  [Symfony\Component\Debug\Exception\FatalThrowableError]              
  Call to undefined method Illuminate\Foundation\Application::share()